### PR TITLE
fix: 'Quiz Completed!' prints at the end of the quiz and not after every question

### DIFF
--- a/main.py
+++ b/main.py
@@ -648,13 +648,13 @@ def do_warpspeed_quiz(driver, sections):
                 # look for incorrect choices; If none were found after click(s), it means we moved on to the next quiz or the quizzes are done
                 if len(driver.find_elements(By.CLASS_NAME, value='rqwrongAns')) == 0:
                     break
-            print('\tQuiz completed!')
         except Exception as e:
             if DEBUGGING:
                 print(e)
             else:
                 print('\tQuiz failed!')
             pass
+    print('\tQuiz completed!')
     return
 
 def assume_task(driver, p="false"):


### PR DESCRIPTION
This merge fixes the issue of `"Quiz Completed!"` being printed after the completion of every question rather than to be printed at the end of the quiz.

Before:
![Screenshot 2023-05-08 152627](https://user-images.githubusercontent.com/73187712/236812168-4b40877c-b722-43b3-a7e7-19d267baedbf.png)

After:
![Screenshot 2023-05-08 165608](https://user-images.githubusercontent.com/73187712/236812229-461c73cd-85bb-40a4-bc0e-3ceb734c14fd.png)
