### PR TITLE
Added an option to skip Movie & TV Punch card

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,11 @@ GOAL='amazon.com'
 # Values: True | False
 AUTOMATE_PUNCHCARD=False
 
+# Option to skip the Movie & TV punchcards
+# Default: False
+# Values: True | False
+SKIP_MOVIES_AND_TV_PUNCHCARD=False
+
 # ** Experimental **
 # Attempts to create a new shopping feature
 # 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ To run this project, you will need to add the following environment variables to
 
 `AUTOMATE_PUNCHCARD` = True or False. Whether bot should automate punchcards.
 
+`SKIP_MOVIES_AND_TV_PUNCHCARD` = True or False. Whether the bot should skip the punchcard for Movies and TV shows.
+
 `CURRENCY` = Currency Symbol or Name, currently only supported by USD($), EURO(€) and INR(₹). Defaults to USD. Plan to add more as more users provide information on their local conversion rates. See .env.example file for an example.
 
 `BOT_NAME` = Bot name, helpful for multiple instances of the bot running with proxy. 

--- a/main.py
+++ b/main.py
@@ -694,7 +694,7 @@ def assume_task(driver, p="false"):
     except:
         pass
 
-def complete_punchcard(driver, skip_movie = False):
+def complete_punchcard(driver):
     try:
         # go to the rewards dashboard
         driver.get('https://rewards.microsoft.com/')
@@ -702,7 +702,7 @@ def complete_punchcard(driver, skip_movie = False):
         sleep(5)
 
         # get all the clickable quest links on the page
-        if (skip_movie):
+        if (SKIP_MOVIES_AND_TV_PUNCHCARD):
             quests = driver.find_elements(By.XPATH, '//*[contains(@class, "clickable-link") and not(contains(@href, "MoviesandTV"))]')
         else:
             quests = driver.find_elements(By.CLASS_NAME, value='clickable-link')
@@ -1330,7 +1330,7 @@ def multi_method(EMAIL, PASSWORD):
     recordTime = datetime.datetime.now(TZ)
     
     if AUTOMATE_PUNCHCARD:
-        complete_punchcard(driver, SKIP_MOVIES_AND_TV_PUNCHCARD)
+        complete_punchcard(driver)
 
     if AUTO_REDEEM:
         redeem(driver, EMAIL)
@@ -1417,7 +1417,7 @@ def start_rewards():
             ranDailySets = daily_set(driver)
             ranMoreActivities = more_activities(driver)
             if AUTOMATE_PUNCHCARD:
-                complete_punchcard(driver, SKIP_MOVIES_AND_TV_PUNCHCARD)
+                complete_punchcard(driver)
     
             if AUTO_REDEEM:
                 redeem(driver, EMAIL)

--- a/main.py
+++ b/main.py
@@ -127,6 +127,11 @@ if (os.environ.get("AUTOMATE_PUNCHCARD", "false").lower() == "true"):
 else:
     AUTOMATE_PUNCHCARD = False
 
+if (os.environ.get("SKIP_MOVIES_AND_TV_PUNCHCARD", "false").lower() == "true"):
+    SKIP_MOVIES_AND_TV_PUNCHCARD = True
+else:
+    SKIP_MOVIES_AND_TV_PUNCHCARD = False
+
 if (os.environ.get("SHOPPING", "false").lower() == "true"):
     SHOPPING = True
 else:
@@ -689,7 +694,7 @@ def assume_task(driver, p="false"):
     except:
         pass
 
-def complete_punchcard(driver):
+def complete_punchcard(driver, skip_movie = False):
     try:
         # go to the rewards dashboard
         driver.get('https://rewards.microsoft.com/')
@@ -697,7 +702,10 @@ def complete_punchcard(driver):
         sleep(5)
 
         # get all the clickable quest links on the page
-        quests = driver.find_elements(By.CLASS_NAME, value='clickable-link')
+        if (skip_movie):
+            quests = driver.find_elements(By.XPATH, '//*[contains(@class, "lickable-link") and not(contains(@href, "MoviesandTV"))]')
+        else:
+            quests = driver.find_elements(By.CLASS_NAME, value='clickable-link')
         # create a list of the links
         links = []
         for quest in quests:
@@ -1322,7 +1330,7 @@ def multi_method(EMAIL, PASSWORD):
     recordTime = datetime.datetime.now(TZ)
     
     if AUTOMATE_PUNCHCARD:
-        complete_punchcard(driver)
+        complete_punchcard(driver, SKIP_MOVIES_AND_TV_PUNCHCARD)
 
     if AUTO_REDEEM:
         redeem(driver, EMAIL)
@@ -1409,7 +1417,7 @@ def start_rewards():
             ranDailySets = daily_set(driver)
             ranMoreActivities = more_activities(driver)
             if AUTOMATE_PUNCHCARD:
-                complete_punchcard(driver)
+                complete_punchcard(driver, SKIP_MOVIES_AND_TV_PUNCHCARD)
     
             if AUTO_REDEEM:
                 redeem(driver, EMAIL)

--- a/main.py
+++ b/main.py
@@ -703,7 +703,7 @@ def complete_punchcard(driver, skip_movie = False):
 
         # get all the clickable quest links on the page
         if (skip_movie):
-            quests = driver.find_elements(By.XPATH, '//*[contains(@class, "lickable-link") and not(contains(@href, "MoviesandTV"))]')
+            quests = driver.find_elements(By.XPATH, '//*[contains(@class, "clickable-link") and not(contains(@href, "MoviesandTV"))]')
         else:
             quests = driver.find_elements(By.CLASS_NAME, value='clickable-link')
         # create a list of the links


### PR DESCRIPTION
Since I’m an Amazon Prime subscriber, I don’t watch shows via Microsoft platforms. So, opening the Movie & TV punch card page is a waste of time for me. I added an option to skip the punch card.